### PR TITLE
Perf: defer render-blocking consent + GTM to fix mobile PageSpeed

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,16 +155,44 @@
 }
 </script>
 
-<!-- consent mode google -->
-<script src="https://app.secureprivacy.ai/script/6a5c2c6d8f68c24d419372cd.js"></script>
-
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-K52NJCLQ');</script>
-<!-- End Google Tag Manager -->
+<!-- Consent (Secure Privacy) + Google Tag Manager.
+     These were previously loaded render-blocking in <head>: the consent
+     script alone cost ~1.6s of render-blocking time and ~1.1s of main-thread
+     work on throttled mobile, dominating the LCP (6.1s) and TBT (1.95s) that
+     tanked the mobile PageSpeed score. They are now loaded after first user
+     interaction (or a short fallback timeout for non-interacting visits and
+     bots), keeping them off the critical rendering path. The consent script
+     still loads FIRST and GTM only after it (via onload), preserving the
+     original order so Google Consent Mode gating is unchanged. -->
+<script>
+  window.dataLayer = window.dataLayer || [];
+  (function () {
+    var loaded = false;
+    function loadTags() {
+      if (loaded) return;
+      loaded = true;
+      ['scroll','mousemove','keydown','touchstart','click'].forEach(function (evt) {
+        window.removeEventListener(evt, loadTags, { passive: true });
+      });
+      // 1) Secure Privacy consent script first (sets consent-mode defaults)
+      var cs = document.createElement('script');
+      cs.src = 'https://app.secureprivacy.ai/script/6a5c2c6d8f68c24d419372cd.js';
+      cs.onload = cs.onerror = function () {
+        // 2) then Google Tag Manager
+        window.dataLayer.push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+        var g = document.createElement('script');
+        g.async = true;
+        g.src = 'https://www.googletagmanager.com/gtm.js?id=GTM-K52NJCLQ';
+        document.head.appendChild(g);
+      };
+      document.head.appendChild(cs);
+    }
+    ['scroll','mousemove','keydown','touchstart','click'].forEach(function (evt) {
+      window.addEventListener(evt, loadTags, { passive: true, once: true });
+    });
+    setTimeout(loadTags, 3000);
+  })();
+</script>
 <!-- Preconnect to external domains -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Problem

Mobile PageSpeed score was **31** (desktop **95**). Lighthouse mobile trace showed the gap came almost entirely from one third party: the **Secure Privacy consent script loaded render-blocking in `<head>`**.

- Render-blocking: **1,616 ms** (secureprivacy)
- Third-party main-thread: **~1,100 ms** blocking (secureprivacy)
- Resulting metrics: LCP **6.1s**, FCP **6.1s**, TBT **1.95s**, TTI **16s**

Desktop hides this (more CPU/bandwidth); throttled mobile (4× CPU, Slow 4G) does not.

## Fix

`index.html`: load the consent script + GTM **after first user interaction** (or a 3s fallback for non-interacting visits/bots), off the critical rendering path. This reuses the deferral pattern already used for `gtag.js` elsewhere in the codebase.

Consent-mode ordering is preserved: the consent script still loads **first**, and GTM only after it (via `onload`).

## Verification (Lighthouse, mobile)

Measured locally before/after (loopback mutes the network cost, so the real-world gain is larger):

| Metric | Before | After |
|---|---|---|
| Score | 87 | **99** |
| FCP | 2.0s | **0.8s** |
| LCP | 3.0s | **1.7s** |
| TBT | 150ms | **100ms** |
| Render-blocking | secureprivacy + CSS | **CSS only** |

## Trade-off

The cookie banner now appears on first interaction or after ~3s instead of instantly. This is the standard trade-off for this optimization and is arguably more compliant (no tags fire before the consent tool loads). Revert this single edit to restore instant loading.

## Deploy / measure

Only `index.html` changes. After deploy, re-run the mobile test at pagespeed.web.dev — the live score updates only after the file is published to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)