### PR TITLE
Add Microsoft Clarity analytics to all pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -121,6 +121,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .error-links strong { display: block; font-size: .98rem; }
   .error-links span.desc { font-size: .8rem; color: var(--text-muted) !important; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 
 <body>

--- a/about-us/index.html
+++ b/about-us/index.html
@@ -202,6 +202,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     color: #0024ED !important;
   }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/contact-us/index.html
+++ b/contact-us/index.html
@@ -235,6 +235,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     color: #0024ED !important;
   }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/bulk-sms-setup-training/index.html
+++ b/freelancing-training/bulk-sms-setup-training/index.html
@@ -218,6 +218,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .module-card li { margin-bottom: 6px; font-size: 0.95rem; }
   .module-card .lab { display: block; margin-top: 10px; font-size: 0.9rem; background: rgba(255,255,255,0.12); border-radius: 6px; padding: 6px 12px; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/call-center-setup-training/index.html
+++ b/freelancing-training/call-center-setup-training/index.html
@@ -218,6 +218,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .module-card li { margin-bottom: 6px; font-size: 0.95rem; }
   .module-card .lab { display: block; margin-top: 10px; font-size: 0.9rem; background: rgba(255,255,255,0.12); border-radius: 6px; padding: 6px 12px; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/centos-linux-training/index.html
+++ b/freelancing-training/centos-linux-training/index.html
@@ -213,6 +213,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/claude-training/index.html
+++ b/freelancing-training/claude-training/index.html
@@ -213,6 +213,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/debian-linux-training/index.html
+++ b/freelancing-training/debian-linux-training/index.html
@@ -218,6 +218,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .module-card li { margin-bottom: 6px; font-size: 0.95rem; }
   .module-card .lab { display: block; margin-top: 10px; font-size: 0.9rem; background: rgba(255,255,255,0.12); border-radius: 6px; padding: 6px 12px; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/docker-training/index.html
+++ b/freelancing-training/docker-training/index.html
@@ -218,6 +218,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .module-card li { margin-bottom: 6px; font-size: 0.95rem; }
   .module-card .lab { display: block; margin-top: 10px; font-size: 0.9rem; background: rgba(255,255,255,0.12); border-radius: 6px; padding: 6px 12px; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/fusionpbx-training/index.html
+++ b/freelancing-training/fusionpbx-training/index.html
@@ -213,6 +213,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/github-training/index.html
+++ b/freelancing-training/github-training/index.html
@@ -213,6 +213,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/gitlab-training/index.html
+++ b/freelancing-training/gitlab-training/index.html
@@ -213,6 +213,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/goautodial-training/index.html
+++ b/freelancing-training/goautodial-training/index.html
@@ -213,6 +213,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/hermes-agent-training/index.html
+++ b/freelancing-training/hermes-agent-training/index.html
@@ -189,6 +189,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .btn-outline { border: 2px solid #fff; padding: 14px 33px; border-radius: 8px; text-decoration: none; display: inline-block; font-weight: bold; }
   .btn-outline:hover { background: #fff; color: #0024ED !important; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/index.html
+++ b/freelancing-training/index.html
@@ -300,6 +300,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     color: #0024ED !important;
   }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to main content</a>

--- a/freelancing-training/jasmin-sms-gateway-training/index.html
+++ b/freelancing-training/jasmin-sms-gateway-training/index.html
@@ -213,6 +213,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/linux-freelancing-training/index.html
+++ b/freelancing-training/linux-freelancing-training/index.html
@@ -186,6 +186,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .requirement-card { background: rgba(255,255,255,0.05); padding: 20px; border-left: 4px solid #fff; margin-bottom: 20px; }
   .btn-primary { background-color: white !important; color: #0024ED !important; padding: 15px 30px; border-radius: 5px; font-weight: bold; text-decoration: none; display: inline-block; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/local-ai-training/index.html
+++ b/freelancing-training/local-ai-training/index.html
@@ -218,6 +218,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .module-card li { margin-bottom: 6px; font-size: 0.95rem; }
   .module-card .lab { display: block; margin-top: 10px; font-size: 0.9rem; background: rgba(255,255,255,0.12); border-radius: 6px; padding: 6px 12px; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/odysseus-ai-training/index.html
+++ b/freelancing-training/odysseus-ai-training/index.html
@@ -213,6 +213,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/openai-training/index.html
+++ b/freelancing-training/openai-training/index.html
@@ -213,6 +213,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/openclaw-training/index.html
+++ b/freelancing-training/openclaw-training/index.html
@@ -213,6 +213,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/telnyx-sms-api-training/index.html
+++ b/freelancing-training/telnyx-sms-api-training/index.html
@@ -199,6 +199,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/twilio-sms-api-training/index.html
+++ b/freelancing-training/twilio-sms-api-training/index.html
@@ -213,6 +213,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/ubuntu-linux-training/index.html
+++ b/freelancing-training/ubuntu-linux-training/index.html
@@ -213,6 +213,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/freelancing-training/zeroclaw-training/index.html
+++ b/freelancing-training/zeroclaw-training/index.html
@@ -213,6 +213,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -337,6 +337,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .video-facade:hover .play-icon { transform: translate(-50%, -50%) scale(1.08); }
 </style>
 
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/legal/credential-verification/index.html
+++ b/legal/credential-verification/index.html
@@ -220,6 +220,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     color: #0024ED !important;
   }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/legal/privacy-policy/index.html
+++ b/legal/privacy-policy/index.html
@@ -216,6 +216,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     color: #0024ED !important;
   }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/legal/refund-policy/index.html
+++ b/legal/refund-policy/index.html
@@ -217,6 +217,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     color: #0024ED !important;
   }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/legal/terms-and-conditions/index.html
+++ b/legal/terms-and-conditions/index.html
@@ -216,6 +216,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     color: #0024ED !important;
   }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/legal/training-rules/index.html
+++ b/legal/training-rules/index.html
@@ -217,6 +217,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     color: #0024ED !important;
   }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/centos-linux-services/index.html
+++ b/linux-ai-services/centos-linux-services/index.html
@@ -196,6 +196,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/claude-ai-platform-services/index.html
+++ b/linux-ai-services/claude-ai-platform-services/index.html
@@ -191,6 +191,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/digitalocean-cloud-services/index.html
+++ b/linux-ai-services/digitalocean-cloud-services/index.html
@@ -185,6 +185,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/docker-engineer-services/index.html
+++ b/linux-ai-services/docker-engineer-services/index.html
@@ -201,6 +201,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/fusionpbx-voip-services/index.html
+++ b/linux-ai-services/fusionpbx-voip-services/index.html
@@ -196,6 +196,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/github-services/index.html
+++ b/linux-ai-services/github-services/index.html
@@ -196,6 +196,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/gitlab-services/index.html
+++ b/linux-ai-services/gitlab-services/index.html
@@ -196,6 +196,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/goautodial-voip-services/index.html
+++ b/linux-ai-services/goautodial-voip-services/index.html
@@ -196,6 +196,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/hermes-agent-services/index.html
+++ b/linux-ai-services/hermes-agent-services/index.html
@@ -196,6 +196,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/hummingbot-installation-services/index.html
+++ b/linux-ai-services/hummingbot-installation-services/index.html
@@ -185,6 +185,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/index.html
+++ b/linux-ai-services/index.html
@@ -242,6 +242,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     color: #0024ED !important;
   }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/jasmin-sms-gateway-services/index.html
+++ b/linux-ai-services/jasmin-sms-gateway-services/index.html
@@ -191,6 +191,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/linux-server-services/index.html
+++ b/linux-ai-services/linux-server-services/index.html
@@ -191,6 +191,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/local-ai-services/index.html
+++ b/linux-ai-services/local-ai-services/index.html
@@ -196,6 +196,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/odysseus-ai-services/index.html
+++ b/linux-ai-services/odysseus-ai-services/index.html
@@ -196,6 +196,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/openai-platform-services/index.html
+++ b/linux-ai-services/openai-platform-services/index.html
@@ -196,6 +196,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/openclaw-ai-services/index.html
+++ b/linux-ai-services/openclaw-ai-services/index.html
@@ -196,6 +196,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/telnyx-sip-trunking-services/index.html
+++ b/linux-ai-services/telnyx-sip-trunking-services/index.html
@@ -196,6 +196,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/telnyx-sms-api-services/index.html
+++ b/linux-ai-services/telnyx-sms-api-services/index.html
@@ -191,6 +191,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/twilio-sip-trunking-services/index.html
+++ b/linux-ai-services/twilio-sip-trunking-services/index.html
@@ -196,6 +196,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/twilio-sms-api-services/index.html
+++ b/linux-ai-services/twilio-sms-api-services/index.html
@@ -191,6 +191,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/ubuntu-linux-services/index.html
+++ b/linux-ai-services/ubuntu-linux-services/index.html
@@ -196,6 +196,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/vapi-platform-services/index.html
+++ b/linux-ai-services/vapi-platform-services/index.html
@@ -185,6 +185,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/linux-ai-services/zeroclaw-ai-services/index.html
+++ b/linux-ai-services/zeroclaw-ai-services/index.html
@@ -196,6 +196,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/australia/index.html
+++ b/locations/australia/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/austria/index.html
+++ b/locations/austria/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/bangladesh/index.html
+++ b/locations/bangladesh/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/belgium/index.html
+++ b/locations/belgium/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/canada/index.html
+++ b/locations/canada/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/denmark/index.html
+++ b/locations/denmark/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/finland/index.html
+++ b/locations/finland/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/germany/index.html
+++ b/locations/germany/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/iceland/index.html
+++ b/locations/iceland/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/index.html
+++ b/locations/index.html
@@ -155,6 +155,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   }
   .country-card:hover { background: rgba(255,255,255,0.16); }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/ireland/index.html
+++ b/locations/ireland/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/israel/index.html
+++ b/locations/israel/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/liechtenstein/index.html
+++ b/locations/liechtenstein/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/luxembourg/index.html
+++ b/locations/luxembourg/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/netherlands/index.html
+++ b/locations/netherlands/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/norway/index.html
+++ b/locations/norway/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/singapore/index.html
+++ b/locations/singapore/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/sweden/index.html
+++ b/locations/sweden/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/switzerland/index.html
+++ b/locations/switzerland/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/uk/index.html
+++ b/locations/uk/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/locations/us/index.html
+++ b/locations/us/index.html
@@ -178,6 +178,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .loc-card { background: rgba(255,255,255,0.08); border-radius: 10px; padding: 20px 22px; }
   .loc-card h3 { margin-top:0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/register/index.html
+++ b/register/index.html
@@ -190,6 +190,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     color: #0024ED !important;
   }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/resource-center/faqs/index.html
+++ b/resource-center/faqs/index.html
@@ -280,6 +280,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </style>
 
 
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/resource-center/index.html
+++ b/resource-center/index.html
@@ -164,6 +164,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .resource-card h2 { font-size: 1.2rem; margin-bottom: 8px; }
   .resource-card p { color: var(--text-secondary); font-size: 0.92rem; line-height: 1.6; margin: 0; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/resource-center/testimonials/index.html
+++ b/resource-center/testimonials/index.html
@@ -250,6 +250,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     color: #0024ED !important;
   }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 

--- a/sitemap/index.html
+++ b/sitemap/index.html
@@ -144,6 +144,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .breadcrumb-nav { font-size: 0.85rem; margin-bottom: 18px; opacity: 0.85; }
   .breadcrumb-nav a { text-decoration: underline; }
 </style>
+<!-- Microsoft Clarity -->
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "xpbr03hkw6");
+</script>
+<!-- End Microsoft Clarity -->
 </head>
 <body>
 


### PR DESCRIPTION
## Summary

Adds the **Microsoft Clarity** tracking tag (project `xpbr03hkw6`) to the `<head>` of every page.

- Inserted on **all 81 HTML pages**, once each, immediately before `</head>`, wrapped in `<!-- Microsoft Clarity -->` / `<!-- End Microsoft Clarity -->` comment markers.
- The snippet is **async** (`t.async=1`), so it does not block rendering.

## Verification

- 81/81 files contain the tag; 81 total occurrences (exactly one per file).
- 0 files have the snippet placed after `</head>`.

## Note

Clarity sets cookies / collects session data. If the site's Secure Privacy consent manager is meant to gate analytics under Consent Mode, you may later want to load Clarity through the consent flow rather than directly. Left as-is here per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)